### PR TITLE
Update der URL fuer 3. Semester Praktikum SWT

### DIFF
--- a/data/ist.json
+++ b/data/ist.json
@@ -155,7 +155,7 @@
       },
       {
         "name":"Praktikum SWT",
-        "url":"http://tu-dresden.de/die_tu_dresden/fakultaeten/fakultaet_informatik/smt/st/studium?leaf=1&lang=de&subject=299"
+        "url":"https://tu-dresden.de/ing/informatik/smt/st/studium/lehrveranstaltungen?leaf=1&lang=de&subject=329&embedding_id=47eddfa7c5a54ed5be49042aff35a31b"
       }
     ]
   },


### PR DESCRIPTION
Der alte Link fuehrte zu einer Seite, zu der man angeblich eine "unzureichende Berechtigung" hat, egal ob man eingeloggt ist oder nicht.
